### PR TITLE
fix: [NMP-20] setup initial docker compose typo fixed

### DIFF
--- a/.github/workflows/pr-close.yml
+++ b/.github/workflows/pr-close.yml
@@ -1,8 +1,10 @@
 name: PR Closed
 
+# Switch back to pull_request to re-enable!
 on:
-  pull_request:
-    types: [closed]
+  workflow_dispatch:
+  # pull_request:
+  #   types: [closed]
 
 concurrency:
   # PR open and close use the same group, allowing only one at a time

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - 5050:80
     environment:
        PGADMIN_DEFAULT_PASSWORD: admin
-       PGADMIN_DEFAULT_EMAIL: admin@nmp.container_name
+       PGADMIN_DEFAULT_EMAIL: admin@qs.com
     networks:
     - quackStack-network
 ###################

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,8 @@ services:
     environment:
       - POSTGRES_HOST=${POSTGRES_HOST:-admin}
       - POSTGRES_USER${POSTGRES_USER:-USER}
-      - POSTGRES_PASSWORD=${POSTGRESS_PASSWORD:-admin}
-      - POSTGRES_DATABASE=${POSTGRESS_DATABASE:-nmp}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-admin}
+      - POSTGRES_DATABASE=${POSTGRES_DATABASE:-nmp}
     ports:
       - 5432:5432
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,8 @@ services:
     environment:
       - POSTGRES_HOST=${POSTGRES_HOST:-admin}
       - POSTGRES_USER${POSTGRES_USER:-USER}
-      - POSTGRESS_PASSWORD=${POSTGRESS_PASSWORD:-admin}
-      - POSTGRESS_DATABASE=${POSTGRESS_DATABASE:-nmp}
+      - POSTGRES_PASSWORD=${POSTGRESS_PASSWORD:-admin}
+      - POSTGRES_DATABASE=${POSTGRESS_DATABASE:-nmp}
     ports:
       - 5432:5432
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,41 @@
+version: "3.9"
+name: quackstack-nmp
+services:
+  ###################
+  #     DB          #
+  ###################
+  database:
+    image: postgres:15
+    container_name: quackStack-db
+    environment:
+      - POSTGRES_HOST=${POSTGRES_HOST:-admin}
+      - POSTGRES_USER${POSTGRES_USER:-USER}
+      - POSTGRESS_PASSWORD=${POSTGRESS_PASSWORD:-admin}
+      - POSTGRESS_DATABASE=${POSTGRESS_DATABASE:-nmp}
+    ports:
+      - 5432:5432
+    healthcheck:
+      test: ["CMD","pg_isready","-U","${POSTGRES_USER:-user}"]
+      interval: 20s
+      timeout: 30s
+      retries: 5
+      start_period: 20s
+  ####################
+  #     PGAdmin      #
+  ####################
+  pgadmin:
+    image: dpage/pgadmin4
+    container_name: quackStack-pgadmin
+    ports:
+      - 5050:80
+    environment:
+       PGADMIN_DEFAULT_PASSWORD: admin
+       PGADMIN_DEFAULT_EMAIL: admin@nmp.container_name
+    networks:
+    - quackStack-network
+###################
+#   Networks      #
+###################
+networks:
+  quackStack-network:
+    driver: "bridge"


### PR DESCRIPTION
Fixed typo with  POSTGRESS_PASSWORD=${POSTGRESS_PASSWORD:-admin} POSTGRESS_DATABASE=${POSTGRESS_DATABASE:-nmp} with a single S, POSTGRES
     

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-sustainment-capstone-2024-35-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-sustainment-capstone-2024-35-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-sustainment-capstone-2024/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-sustainment-capstone-2024/actions/workflows/merge.yml)