### PR TITLE
fix: Fixed build and serve misconfiguration

### DIFF
--- a/backend/.eslintrc.cjs
+++ b/backend/.eslintrc.cjs
@@ -1,3 +1,5 @@
+const { off } = require("process");
+
 module.exports = {
   root: true,
   env: { es2020: true },
@@ -18,6 +20,7 @@ module.exports = {
         'import/no-absolute-path': 'off', // Disables the rule for absolute import paths
         'no-unresolved-imports': 'off', // Disables the rule for unresolved imports (not a standard ESLint rule)
         'import/no-wildcard': 'off',
+        'import/extensions': 'off',
       },
     },
   ],

--- a/backend/.eslintrc.cjs
+++ b/backend/.eslintrc.cjs
@@ -1,5 +1,3 @@
-const { off } = require("process");
-
 module.exports = {
   root: true,
   env: { es2020: true },
@@ -21,6 +19,7 @@ module.exports = {
         'no-unresolved-imports': 'off', // Disables the rule for unresolved imports (not a standard ESLint rule)
         'import/no-wildcard': 'off',
         'import/extensions': 'off',
+        'no-console': 'off'
       },
     },
   ],

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "ts-node src/server.ts",
     "build": "tsc",
-    "serve": "node src/server.ts",
+    "serve": "node dist/server.js",
     "dev": "nodemon src/server.ts",
     "lint": "eslint",
     "format": "prettier . --write"

--- a/backend/src/express.ts
+++ b/backend/src/express.ts
@@ -1,3 +1,4 @@
+/* eslint-disable import/extensions */
 // Middleware is activated here
 // Any processing of HTTP Requests is done here
 // before routing them to their target endpoints
@@ -8,8 +9,8 @@ import morgan from 'morgan';
 import cors from 'cors';
 import swaggerUi from 'swagger-ui-express';
 import swaggerJSDoc from 'swagger-jsdoc';
-import swaggerConfig from './config/swaggerConfig.ts';
-import * as routers from './routes/index.ts';
+import swaggerConfig from './config/swaggerConfig';
+import * as routers from './routes/index';
 
 const app = express();
 

--- a/backend/src/routes/health-router.ts
+++ b/backend/src/routes/health-router.ts
@@ -1,7 +1,7 @@
 // Root|/api endpoint router
 // Any routes in /api can be accessed through here
 import express from 'express';
-import checkHealth from '../controllers/health-api-controller.ts';
+import checkHealth from '../controllers/health-api-controller';
 
 const router = express.Router();
 

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -1,2 +1,2 @@
 // eslint-disable-next-line import/prefer-default-export
-export { default as healthRouter } from './health-router.ts';
+export { default as healthRouter } from './health-router';

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -2,7 +2,7 @@
 // It's the first file called when running this API
 // It hands HTTP Requests to ./express.ts
 import dotenv from 'dotenv';
-import app from './express.ts';
+import app from './express';
 
 // Get environment variables from .env file using DotEnv
 dotenv.config();
@@ -12,5 +12,6 @@ const API_PORT = process.env.API_PORT || 3000;
 
 // Start HTTP Server
 app.listen(API_PORT, () => {
+  // eslint-disable-next-line no-console
   console.info(`Server running on port: ${API_PORT}`);
 });

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -12,6 +12,5 @@ const API_PORT = process.env.API_PORT || 3000;
 
 // Start HTTP Server
 app.listen(API_PORT, () => {
-  // eslint-disable-next-line no-console
   console.info(`Server running on port: ${API_PORT}`);
 });

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -7,8 +7,6 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "allowImportingTsExtensions": true,
-    "noEmit": true
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
Now building transpiles ts to js into ./dist and serving serves it

<!-- Provide a general summary of your changes in the Title above -->

# Description

`npm run build` would transpile code into `./dist` but `npm run serve` would not serve transpiled code.
Some package.json and .tsconfig config was changed to fix this.
ESlint was also updated since `noEmit` was wrongfully added.  

## Type of changes

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-sustainment-capstone-2024-58-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-sustainment-capstone-2024-58-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-sustainment-capstone-2024/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-sustainment-capstone-2024/actions/workflows/merge.yml)