### PR TITLE
feat: Bb 158 create reusable input field

### DIFF
--- a/frontend/src/Commons/Button/Button.style.ts
+++ b/frontend/src/Commons/Button/Button.style.ts
@@ -2,12 +2,12 @@ import styled from '@emotion/styled';
 import * as tokens from '@bcgov/design-tokens/js';
 import screenSizes from '@Constants/ScreenSize';
 
-type ButtonProps = {
+type StyledButtonProps = {
   size: string;
   disabled: boolean;
 };
 
-const StyledButton = styled.button<ButtonProps>`
+const StyledButton = styled.button<StyledButtonProps>`
   display: flex;
   align-items: center;
   justify-content: center;

--- a/frontend/src/Commons/Forms/InputModules/FarmInformation/FarmInformation.style.ts
+++ b/frontend/src/Commons/Forms/InputModules/FarmInformation/FarmInformation.style.ts
@@ -4,6 +4,7 @@
  * @author @GDamaso
  */
 import styled from '@emotion/styled';
+import screenSizes from '@Constants/ScreenSize';
 
 const StyledFarmInfo = styled.div`
   display: flex;
@@ -14,9 +15,18 @@ const StyledFarmInfo = styled.div`
   p {
     margin: 8px 0 0 0;
   }
+
+  #inputContainer {
+    @media (min-width: ${screenSizes.desktop}) {
+      display: flex;
+      flex-direction: row;
+      width: 50%;
+      gap: 30px;
+    }
+  }
 `;
 
-const StyledButtonContainer = styled.div`
+const StyledSelectContainer = styled.div`
   display: flex;
   flex-direction: row;
   justify-content: space-between;
@@ -26,7 +36,7 @@ const StyledButtonContainer = styled.div`
 
   select {
     height: 30px;
-    width: 80%;
+    width: 50%;
   }
 `;
-export { StyledFarmInfo, StyledButtonContainer };
+export { StyledFarmInfo, StyledSelectContainer };

--- a/frontend/src/Commons/Forms/InputModules/FarmInformation/FarmInformation.tsx
+++ b/frontend/src/Commons/Forms/InputModules/FarmInformation/FarmInformation.tsx
@@ -69,7 +69,7 @@ const FarmInfoComponent: React.FC<InputModuleProps> = ({ farmDetails, updateFarm
             />
 
             <CustomField
-              label="Name"
+              label="Farm Name"
               id="FarmName"
               name="FarmName"
               type="text"

--- a/frontend/src/Commons/Forms/InputModules/FarmInformation/FarmInformation.tsx
+++ b/frontend/src/Commons/Forms/InputModules/FarmInformation/FarmInformation.tsx
@@ -11,7 +11,8 @@ import FarmDetailsInterface from 'src/Interface/FarmDetailsInterface';
 import ComponentText from '@Constants/ComponentText';
 import { Formik, Field, Form, ErrorMessage } from 'formik';
 import * as Yup from 'yup';
-import { StyledFarmInfo, StyledButtonContainer } from './FarmInformation.style';
+import CustomField from '@Commons/Input/CustomField';
+import { StyledFarmInfo, StyledSelectContainer } from './FarmInformation.style';
 
 interface SubmissionValues {
   FarmName: string;
@@ -58,30 +59,27 @@ const FarmInfoComponent: React.FC<InputModuleProps> = ({ farmDetails, updateFarm
     >
       <Form>
         <StyledFarmInfo>
-          <label htmlFor="FarmName">
-            <p>Name</p>
-          </label>
-          <Field
-            id="FarmName"
-            name="FarmName"
-            type="text"
-          />
-          <ErrorMessage name="FarmName" />
+          <div id="inputContainer">
+            <CustomField
+              label="Year"
+              id="Year"
+              name="Year"
+              type="number"
+              width="20%"
+            />
 
-          <label htmlFor="Year">
-            <p>Year</p>
-          </label>
-          <Field
-            id="Year"
-            name="Year"
-            type="number"
-          />
-          <ErrorMessage name="Year" />
+            <CustomField
+              label="Name"
+              id="FarmName"
+              name="FarmName"
+              type="text"
+            />
+          </div>
 
           <label htmlFor="FarmRegion">
             <p>Region</p>
           </label>
-          <StyledButtonContainer>
+          <StyledSelectContainer>
             <Field
               name="FarmRegion"
               as="select"
@@ -95,7 +93,7 @@ const FarmInfoComponent: React.FC<InputModuleProps> = ({ farmDetails, updateFarm
             />
 
             <button type="submit">{ComponentText.NEXT}</button>
-          </StyledButtonContainer>
+          </StyledSelectContainer>
         </StyledFarmInfo>
       </Form>
     </Formik>

--- a/frontend/src/Commons/Input/CustomField.style.ts
+++ b/frontend/src/Commons/Input/CustomField.style.ts
@@ -1,0 +1,31 @@
+/**
+ * @desc Styling with BC Design Tokens and Emotion for Footer component
+ * @author @GDamaso
+ */
+import styled from '@emotion/styled';
+import * as tokens from '@bcgov/design-tokens/js';
+import screenSizes from '@Constants/ScreenSize';
+
+type StyledFieldProps = {
+  width: string;
+};
+
+const StyledField = styled.div<StyledFieldProps>`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  label {
+    font-weight: ${tokens.typographyFontWeightsBold};
+  }
+
+  input {
+    border: solid 1px ${tokens.themeGray40};
+    border-radius: 3px;
+  }
+
+  @media (min-width: ${screenSizes.desktop}) {
+    width: ${(props) => props.width};
+  }
+`;
+
+export default StyledField;

--- a/frontend/src/Commons/Input/CustomField.tsx
+++ b/frontend/src/Commons/Input/CustomField.tsx
@@ -1,0 +1,30 @@
+/**
+ * @desc A footer with links to our terms of agreement and BC NMP Help resource
+ *@author @GDamaso
+ */
+import { Field, ErrorMessage } from 'formik';
+import StyledField from './CustomField.style';
+
+interface CustomFieldProps {
+  label: string;
+  name: string;
+  id: string;
+  type: string;
+  width?: string;
+}
+
+const CustomField: React.FC<CustomFieldProps> = ({ name, id, type, label, width = '100%' }) => (
+  <StyledField width={width}>
+    <label htmlFor={id}>
+      <p>{label}</p>
+    </label>
+    <Field
+      name={name}
+      id={id}
+      type={type}
+    />
+    <ErrorMessage name={id} />
+  </StyledField>
+);
+
+export default CustomField;

--- a/frontend/src/Commons/Input/CustomField.tsx
+++ b/frontend/src/Commons/Input/CustomField.tsx
@@ -3,6 +3,7 @@
  *@author @GDamaso
  */
 import { Field, ErrorMessage } from 'formik';
+import { FC } from 'react';
 import StyledField from './CustomField.style';
 
 interface CustomFieldProps {
@@ -13,7 +14,7 @@ interface CustomFieldProps {
   width?: string;
 }
 
-const CustomField: React.FC<CustomFieldProps> = ({ name, id, type, label, width = '100%' }) => (
+const CustomField: FC<CustomFieldProps> = ({ name, id, type, label, width = '100%' }) => (
   <StyledField width={width}>
     <label htmlFor={id}>
       <p>{label}</p>

--- a/frontend/src/Commons/MainPageHeader/MainPageHeader.styles.ts
+++ b/frontend/src/Commons/MainPageHeader/MainPageHeader.styles.ts
@@ -15,8 +15,8 @@ const StyledHeader = styled.header`
   width: 100%;
   padding: 10px;
   background-color: ${tokens.themeBlue100};
-  position:fixed;
-  top:0;
+  position: fixed;
+  top: 0;
   color: ${tokens.typographyColorPrimaryInvert};
   border-bottom: ${tokens.layoutBorderWidthMedium} solid ${tokens.themeGold100};
   @media (min-width: ${screenSizes.tablet}) and (max-width: ${screenSizes.desktop}) {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

### Implemented a reusable, custom Formik Field Component

Now Instead of using formiks `Field` component like this:
```javascript
          <label htmlFor="FarmName">
            <p>Name</p>
          </label>
          <Field
            id="FarmName"
            name="FarmName"
            type="text"
          />
          <ErrorMessage name="FarmName" />
```
We can use:
```javascript
            <CustomField
              label="Year"
              id="Year"
              name="Year"
              type="number"
              width="20%"
            />
```

It has the same effect with less overhead, making it easier to reuse. There is also some default styling so we can skip doing that on every InputModules Field.
Width is optional and takes a string, like a normal css `width` attribute. It defaults to `100%`

## Type of changes

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

![ReusableInputDemo](https://github.com/bcgov/nr-sustainment-capstone-2024/assets/80939533/f480af66-35fb-477f-9ef9-d60ab4aa9926)



---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-sustainment-capstone-2024-177-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-sustainment-capstone-2024-177-backend.apps.silver.devops.gov.bc.ca/api/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-sustainment-capstone-2024/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-sustainment-capstone-2024/actions/workflows/merge.yml)

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-sustainment-capstone-2024-177-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-sustainment-capstone-2024-177-backend.apps.silver.devops.gov.bc.ca/api/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-sustainment-capstone-2024/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-sustainment-capstone-2024/actions/workflows/merge.yml)