### PR TITLE
fix: stringfy of non JSON data bug

### DIFF
--- a/frontend/src/Views/LandingPage/LandingPage.tsx
+++ b/frontend/src/Views/LandingPage/LandingPage.tsx
@@ -29,13 +29,15 @@ const LandingPage = () => {
 
     fr.onload = () => {
       const data = fr.result;
-      if (data) localStorage.setItem(Names.FARM_DETAILS, JSON.stringify(data));
+      // data is not a JSON yet at this point. It's still .nmp
+      if (data) localStorage.setItem(Names.FARM_DETAILS, data.toString());
     };
     window.location.href = '/main';
   };
 
   const newCalcHandler = () => {
     localStorage.clear();
+    // Our template is a JSON .nmp compatible object
     localStorage.setItem(Names.FARM_DETAILS, JSON.stringify(templateNMP));
     window.location.href = '/main';
   };


### PR DESCRIPTION
Load functionally was broken by stringfying non JSON, .nmp object.

Reverted from JSON.stringfy to the toString method.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-sustainment-capstone-2024-235-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-sustainment-capstone-2024-235-backend.apps.silver.devops.gov.bc.ca/api/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-sustainment-capstone-2024/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-sustainment-capstone-2024/actions/workflows/merge.yml)