### PR TITLE
fix(ci): wwitch to Recreate deployments, reduce db size

### DIFF
--- a/backend/openshift.deploy.yml
+++ b/backend/openshift.deploy.yml
@@ -45,7 +45,7 @@ objects:
       name: ${APP}-${TARGET}-${COMPONENT}
     spec:
       strategy:
-        type: RollingUpdate
+        type: Recreate
       selector:
         matchLabels:
           deployment: ${APP}-${TARGET}-${COMPONENT}

--- a/database/openshift.deploy.yml
+++ b/database/openshift.deploy.yml
@@ -66,7 +66,7 @@ objects:
         - ReadWriteOnce
       resources:
         requests:
-          storage: 256Mi
+          storage: 128Mi
       storageClassName: netapp-file-standard
   - kind: Deployment
     apiVersion: apps/v1

--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -41,7 +41,7 @@ objects:
       name: ${APP}-${TARGET}-${COMPONENT}
     spec:
       strategy:
-        type: RollingUpdate
+        type: Recreate
       selector:
         matchLabels:
           deployment: ${APP}-${TARGET}-${COMPONENT}


### PR DESCRIPTION
This project appears to be running out of resources and silently failing during deployments.  This is most problematic for TEST.  

Changes:
- reduce database pvc from 256 mb to 128 mb
- use recreate instead of rolling deployments (delete first, frees resources)

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-sustainment-capstone-2024-285-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-sustainment-capstone-2024-285-backend.apps.silver.devops.gov.bc.ca/api/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-sustainment-capstone-2024/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-sustainment-capstone-2024/actions/workflows/merge.yml)