### PR TITLE
fix: Fix zeros being loaded instead of fert names

### DIFF
--- a/frontend/src/Utils/convertToNMP.ts
+++ b/frontend/src/Utils/convertToNMP.ts
@@ -15,7 +15,6 @@ import {
 } from '@Constants/FertilizersOptions';
 import OptionInterface from '@Interface/OptionInterface';
 import NmpFertilizerInterface from '@Interface/NmpFertilizerInterface';
-import getFertilizerOption from './getFertID';
 
 function getOptionIndex(options: OptionInterface[], val: string): number {
   return options.findIndex((option) => option.value === val) + 1;
@@ -85,10 +84,7 @@ const convertToNMP = (
               return {
                 id: nutrient.id,
                 fertilizerTypeId: getOptionIndex(FertilizerTypeOptions, nutrient.fertilizerTypeId),
-                fertilizerId: parseInt(
-                  getFertilizerOption(nutrient.fertilizerId)?.value ?? '0',
-                  10,
-                ),
+                fertilizerId: parseInt(nutrient.fertilizerId, 10),
                 applRate: nutrient.applRate,
                 applUnitId: isFertDry
                   ? getOptionIndex(DryApplicationUnits, nutrient.applUnitId)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Simple ammend to the loading ticket, parseInt was missing a radix which husky caught and stopped the commit from being pushed. Didn't notice it wasn't added before merging, resulting in this quick pr :smile: 

The fix is for zeros being loaded in place of fertilizer names. To fix it I simplified the code I realised was overcomplicated and not working properly. It required a fallback since it was using a find(), which could return undefined. The fallback was zero. Now there's no need for it since fertilizers were updated to match nmp id's, making it easier to assign their names according to their id's.

## Type of changes

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-sustainment-capstone-2024-321-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-sustainment-capstone-2024-321-backend.apps.silver.devops.gov.bc.ca/api/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-sustainment-capstone-2024/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-sustainment-capstone-2024/actions/workflows/merge.yml)